### PR TITLE
Add copyright text to bash scripts

### DIFF
--- a/check-ac
+++ b/check-ac
@@ -1,3 +1,9 @@
+# Copyright (C) 2025 sppidy
+#
+# This file is a part of <https://github.com/sppidy/scripts>
+# Please read the GNU General Public License in
+# <https://www.github.com/sppidy/scripts/blob/main/LICENSE/>.
+
 #!/bin/bash
 AC_DIR=$(ls /sys/class/power_supply/ | grep -E "^AC|^AC0|^ACAD" | head -n 1)
 

--- a/cpu-boost
+++ b/cpu-boost
@@ -1,3 +1,9 @@
+# Copyright (C) 2025 sppidy
+#
+# This file is a part of <https://github.com/sppidy/scripts>
+# Please read the GNU General Public License in
+# <https://www.github.com/sppidy/scripts/blob/main/LICENSE/>.
+
 #!/bin/bash
 
 if [[ -z "$1" || ! "$1" =~ ^[01]$ ]]; then
@@ -33,4 +39,3 @@ while [[ $# -gt 1 ]]; do
             ;;
     esac
 done
-

--- a/cpu-tools
+++ b/cpu-tools
@@ -1,4 +1,11 @@
+# Copyright (C) 2025 sppidy
+#
+# This file is a part of <https://github.com/sppidy/scripts>
+# Please read the GNU General Public License in
+# <https://www.github.com/sppidy/scripts/blob/main/LICENSE/>.
+
 #!/bin/bash
+
 total_cores=$1
 
 if [[ -z "$1" || ! "$1" =~ ^[0-9]+$ ]]; then
@@ -80,4 +87,3 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
-

--- a/gofile-uploader.sh
+++ b/gofile-uploader.sh
@@ -1,3 +1,9 @@
+# Copyright (C) 2025 sppidy
+#
+# This file is a part of <https://github.com/sppidy/scripts>
+# Please read the GNU General Public License in
+# <https://www.github.com/sppidy/scripts/blob/main/LICENSE/>.
+
 #!/bin/bash
 
 # Check if curl, jq, and ping are installed


### PR DESCRIPTION
Add copyright text to the top of `check-ac`, `cpu-boost`, `cpu-tools`, and `gofile-uploader.sh`.

* Add copyright text to the top of `check-ac`
* Add copyright text to the top of `cpu-boost`
* Add copyright text to the top of `cpu-tools`
* Add copyright text to the top of `gofile-uploader.sh`
